### PR TITLE
Change rpc endpoint

### DIFF
--- a/diafora_7213778-1/diafora_7213778-1.json
+++ b/diafora_7213778-1/diafora_7213778-1.json
@@ -1,8 +1,8 @@
 {
   "chainId": "diafora_7213778-1",
   "chainName": "Diafora",
-  "rpc": "https://froopyland.dymension.xyz/5/diafora_7213778-1/rpc",
-  "rest": "https://froopyland.dymension.xyz/5/diafora_7213778-1/rest",
+  "rpc": "http://78.46.78.155:46657",
+  "rest": "http://78.46.78.155:4317",
   "bech32Prefix": "ethm",
   "currencies": [
     {
@@ -24,7 +24,7 @@
   },
   "evm": {
     "chainId": "0x6e12d2",
-    "rpc": "https://froopyland.dymension.xyz/5/diafora_7213778-1/evmrpc"
+    "rpc": "http://78.46.78.155:4545"
   },
   "type": "RollApp",
   "da": "Celestia",


### PR DESCRIPTION
The RPC endpoint must be replaced for smooth testing because the current server is unstable which results in frequent errors