### PR TITLE
Update jembutkucing_9748260-1.json

### DIFF
--- a/devnet/jembutkucing_9748260-1/jembutkucing_9748260-1.json
+++ b/devnet/jembutkucing_9748260-1/jembutkucing_9748260-1.json
@@ -18,8 +18,8 @@
   "website": "",
   "logo": "/logos/jembutkucing_9748260-1.png",
   "ibc": {
-    "hubChannel": "channel-5394",
-    "channel": "channel-0",
+    "hubChannel": "channel-8114",
+    "channel": "channel-1",
     "timeout": 172800000
   },
   "evm": {


### PR DESCRIPTION
Updated the ibc channel, reason: Error due to expiration