### PR TITLE
Change DA to avail goldberg

### DIFF
--- a/devnet/jembutkucing_9748260-1/jembutkucing_9748260-1.json
+++ b/devnet/jembutkucing_9748260-1/jembutkucing_9748260-1.json
@@ -15,7 +15,7 @@
   ],
   "coinType": 60,
   "faucetUrl": "https://discord.com/channels/956961633165529098/1143231362468434022",
-  "website": "",
+  "website": "https://rollapp.jembutkucing.tech",
   "logo": "/logos/jembutkucing_9748260-1.png",
   "ibc": {
     "hubChannel": "channel-8114",
@@ -28,6 +28,8 @@
   },
   "type": "RollApp",
   "da": "Avail",
-  "description": "",
-  "analytics": true
+  "description": "Test Jembut Rollapp",
+  "analytics": true,
+  "goldberg": true,
+  "availAddress": "5GeQCSk7gsNo8zTiuscnCgjSThraYweYKx4qZZxCy6tkCd4o"
 }


### PR DESCRIPTION
This change is required to participate in the clash of nodes event, avail